### PR TITLE
Typo with Soundtouch

### DIFF
--- a/src/plivo/rest/freeswitch/api.py
+++ b/src/plivo/rest/freeswitch/api.py
@@ -2073,7 +2073,7 @@ class PlivoRestApi(object):
         if pitch_p:
             try:
                 pitch_p = float(pitch_p)
-                if pitch_o <= 0:
+                if pitch_p <= 0:
                     msg = "Pitch Parameter must be > 0"
                     return self.send_response(Success=result, Message=msg)
             except (ValueError, TypeError):


### PR DESCRIPTION
It is double-checking the `PitchOctave` parameter instead of the `Pitch` param. This means that it will not allow `Pitch` without `PitchOctave`.
