### PR TITLE
Wavstream fails

### DIFF
--- a/src/plivo/core/freeswitch/commands.py
+++ b/src/plivo/core/freeswitch/commands.py
@@ -470,7 +470,7 @@ class Commands(object):
         regexp = '|'.join(reg)
         regexp = '^(%s)+' % regexp
 
-        args = "%d %d %d %d '%s' %s %s %s %s %d" % (min_digits, max_digits, max_tries, \
+        args = "%d %d %d %d '%s' '%s' %s %s %s %d" % (min_digits, max_digits, max_tries, \
                                                     timeout, terminators, play_str,
                                                     invalid_file, var_name, regexp,
                                                     digit_timeout)


### PR DESCRIPTION
Hi Guys,
### We got an issue here :

2012-02-27 21:08:04,368 plivo-outbound[18522]: DEBUG: (1) Execute: play_and_get_digits args=1 1 1 10000 '#' file_string://silence_stream://1!shell_stream:///usr/share/plivo/bin/wavstream.sh http://127.0.0.1:8089/Cache/?url=http%3A%2F%2F127.0.0.1%3A8000%2Fmediafiles%2Fupload%2Faudiofiles%2Faudio-file-TSQPP-8328233275.wav silence_stream://150 pagd_input ^(0|1|2|3|4|5|6|7|8|9)+ 10000, uuid='', lock=True, loops=1
### This result in Freeswitch with the following error :

Traceback (most recent call last):
  File "/usr/share/plivo/bin/wavdump.py", line 7, in <module>
    execfile(**file**)
  File "/usr/share/plivo/src/plivo/src/bin/wavdump.py", line 6, in <module>
    handler = urllib2.urlopen(req)
  File "/usr/lib/python2.7/urllib2.py", line 126, in urlopen
    return _opener.open(url, data, timeout)
  File "/usr/lib/python2.7/urllib2.py", line 383, in open
    protocol = req.get_type()
  File "/usr/lib/python2.7/urllib2.py", line 245, in get_type
    raise ValueError, "unknown url type: %s" % self.__original
ValueError: unknown url type: -r
sox FAIL formats: can't open input  `-': WAVE: RIFF header not found
2012-02-27 21:08:15.088663 [ERR] switch_core_file.c:122 Invalid file format [http] for [127.0.0.1:8089/Cache/?url=http%3A%2F%2F127.0.0.1%3A8000%2Fmediafiles%2Fupload%2Faudiofiles%2Faudio-file-TSQPP-8328233275.wav]!

Solved with the attached patch!
