### PR TITLE
Added new Callback element

### DIFF
--- a/src/plivo/rest/freeswitch/elements.py
+++ b/src/plivo/rest/freeswitch/elements.py
@@ -118,7 +118,7 @@ ELEMENTS_DEFAULT_PARAMS = {
                 #url: SET IN ELEMENT BODY
                 'method': 'POST'
         },
-        'Callback': {
+        'Notify': {
                 #url: SET IN ELEMENT BODY
                 'method': 'POST'
         },
@@ -1561,7 +1561,7 @@ class Redirect(Element):
             return
         raise RESTFormatException("Redirect must have an URL")
 
-class Callback(Element):
+class Notify(Element):
     """Callback to Url to notify this element has been executed.
     Url is set in element body
     method: GET or POST
@@ -1578,16 +1578,16 @@ class Callback(Element):
             raise RESTAttributeException("Method must be 'GET' or 'POST'")
         url = element.text.strip()
         if not url:
-            raise RESTFormatException("Callback must have an URL")
+            raise RESTFormatException("Notify must have an URL")
         if is_valid_url(url):
             self.method = method
             self.url = url
             return
-        raise RESTFormatException("Callback URL '%s' not valid!" % str(url))
+        raise RESTFormatException("Notify URL '%s' not valid!" % str(url))
 
     def execute(self, outbound_socket):
         if not self.url:
-            raise RESTFormatException("Callback must have an URL")
+            raise RESTFormatException("Notify must have an URL")
 
         if self.method is None:
             self.method = outbound_socket.default_http_method


### PR DESCRIPTION
I've added support for the `Callback` element. This will send an HTTP request to the URL specified when the XML element is executed. This lets the developer know when a specific part of the XML has been reached. For example, this can allow the developer to perform `mod_soundtouch` commands via the REST API after the first `Speak` is executed.
### Sample Usage

```
<Response>
    <Speak engine="cepstral" voice="Allison-8kHz">Before Callback</Speak>
    <Callback>http://localhost:8001/speak-executed/</Callback>
    <Speak engine="cepstral" voice="Allison-8kHz">After Callback</Speak>
</Response>
```

The callback URL will receive the following params after the elements before `Callback` are executed:

```
[To] => 15553470933
[Direction] => inbound
[From] => 1004
[CallerName] => Plivo
[CallUUID] => fcfd25e5-246e-4200-8400-b2b56845c68d
[CallStatus] => in-progress
```
