### PR TITLE
Fix issue where GetDigits with Speak

### DIFF
--- a/src/plivo/core/freeswitch/commands.py
+++ b/src/plivo/core/freeswitch/commands.py
@@ -470,7 +470,7 @@ class Commands(object):
         regexp = '|'.join(reg)
         regexp = '^(%s)+' % regexp
 
-        play_str = play_str.replace("'", "\'")
+        play_str = play_str.replace("'", "\\'")
 
         args = "%d %d %d %d '%s' '%s' %s %s %s %d" % (min_digits, max_digits, max_tries, \
                                                     timeout, terminators, play_str,


### PR DESCRIPTION
Only one word would be spoken if there was a `Speak` inside a `GetDigits`
