### PR TITLE
Fix Multiple Grammars

### DIFF
--- a/src/plivo/rest/freeswitch/elements.py
+++ b/src/plivo/rest/freeswitch/elements.py
@@ -1809,33 +1809,8 @@ class GetSpeech(Element):
                 # set grammar tag name
                 grammar_tag = os.path.basename(grammar_file)
 
-                if i != len(grammars) - 1:
-                    # define grammar
-                    speech_args = "grammar %s %s" % (grammar_full_path, grammar_tag)
-                    res = outbound_socket.execute("detect_speech", speech_args)
-                    if not res.is_success():
-                        outbound_socket.log.error("GetSpeech Failed - %s" \
-                                                      % str(res.get_response()))
-                        if gpath:
-                            try:
-                                os.remove(gpath)
-                            except:
-                                pass
-                        return
-                    # enable grammar
-                    speech_args = "grammaron %s" % (grammar_full_path)
-                    res = outbound_socket.execute("detect_speech", speech_args)
-                    if not res.is_success():
-                        outbound_socket.log.error("GetSpeech Failed - %s" \
-                                                      % str(res.get_response()))
-                        if gpath:
-                            try:
-                                os.remove(gpath)
-                            except:
-                                pass
-                        return
-                else:
-                    # start detection
+                if i == 0:
+                    # init detection
                     speech_args = "%s %s %s" % (self.engine, grammar_full_path, grammar_tag)
                     res = outbound_socket.execute("detect_speech", speech_args)
                     if not res.is_success():
@@ -1849,8 +1824,34 @@ class GetSpeech(Element):
                         return
                     else:
                         grammar_loaded = True
+                else:
+                    # define grammar
+                    speech_args = "grammar %s %s" % (grammar_full_path, grammar_tag)
+                    res = outbound_socket.execute("detect_speech", speech_args)
+                    if not res.is_success():
+                        outbound_socket.log.error("GetSpeech Failed - %s" \
+                                                      % str(res.get_response()))
+                        if gpath:
+                            try:
+                                os.remove(gpath)
+                            except:
+                                pass
+                        return
+                # enable grammar
+                speech_args = "grammaron %s" % (grammar_tag)
+                res = outbound_socket.execute("detect_speech", speech_args)
+                if not res.is_success():
+                    outbound_socket.log.error("GetSpeech Failed - %s" \
+                                                  % str(res.get_response()))
+                    if gpath:
+                        try:
+                            os.remove(gpath)
+                        except:
+                            pass
+                    return
 
         if grammar_loaded == True:
+            outbound_socket.execute("detect_speech", "resume")
             for child_instance in self.children:
                 if isinstance(child_instance, Play):
                     sound_file = child_instance.sound_file_path


### PR DESCRIPTION
I made an incorrect assumption with the way multiple grammar loading in FreeSWITCH worked, so the last patch was doing it incorrectly.

From `mod_unimrcp.c` lines 3085-3097, inside `recog_asr_load_grammar()`:

``` C
    start_recognize = (char *) switch_core_hash_find(schannel->params, "start-recognize");
    if (zstr(start_recognize) || strcasecmp(start_recognize, "false"))
    {
        if (recog_channel_disable_all_grammars(schannel) != SWITCH_STATUS_SUCCESS) {
            status = SWITCH_STATUS_FALSE;
            goto done;
        }
        if (recog_channel_enable_grammar(schannel, name) != SWITCH_STATUS_SUCCESS) {
            status = SWITCH_STATUS_FALSE;
            goto done;
        }
        status = recog_channel_start(schannel);
    }
```

As you can see unless `start-recognize` is set to `false` in your unimrcp profile (under `<recogparams/>`) FreeSWITCH will _disable_ all grammars whenever you load one. Which means recognition will only work for the last grammar you load. Also, you need to initialize speech detection with a `detect_speech` call _before_ loading other grammars. You should have in your profile something like:

``` xml
    <recogparams>
        <param name="start-recognize" value="false" />
    </recogparams>
```

This patch makes sure to initialize detection first, then load grammars second, then finally after all are loaded running a `detect_speech resume` to start using them all. However multiple grammars will **only work if `start-recognize` is set to `false`** as mentioned above.

This seems to be working well for me to load multiple grammars, including DTMF grammars with LumenVox; and I am getting speech results properly for any matches to the grammars.
