### PR TITLE
shout can not play wav files.

### DIFF
--- a/src/plivo/rest/freeswitch/helpers.py
+++ b/src/plivo/rest/freeswitch/helpers.py
@@ -345,12 +345,14 @@ def get_resource(socket, url):
         socket.log.error("Cache Error !")
         socket.log.error("Cache Error: %s" % str(e))
 
-    if url[:7].lower() == "http://":
-        audio_path = url[7:]
-        url = "shout://%s" % audio_path
+     if url[:7].lower() == "http://":
+        if url[-4:] != ".wav":
+            audio_path = url[7:]
+            url = "shout://%s" % audio_path
     elif url[:8].lower() == "https://":
-        audio_path = url[8:]
-        url = "shout://%s" % audio_path
+        if url[-4:] != ".wav":
+            audio_path = url[8:]
+            url = "shout://%s" % audio_path
 
     return url
 


### PR DESCRIPTION
shout can not play wav files, and FS can play wav files by itself even on http(s).
sometimes you should use http url + wav file, e.g. when you want generate wav files by your web framework on the url or any other things.
