### PR TITLE
freeswitch: change FS_GIT_REPO to stash.freeswitch.org

### DIFF
--- a/freeswitch/install.sh
+++ b/freeswitch/install.sh
@@ -6,7 +6,7 @@
 
 
 FS_CONF_PATH=https://github.com/plivo/plivoframework/raw/master/freeswitch
-FS_GIT_REPO=git://git.freeswitch.org/freeswitch.git
+FS_GIT_REPO=https://stash.freeswitch.org/scm/fs/freeswitch.git
 FS_INSTALLED_PATH=/usr/local/freeswitch
 
 #####################################################


### PR DESCRIPTION
Seems like the old URL is dead.
