### PR TITLE
freeswitch: fix cloning the stable branch

### DIFF
--- a/freeswitch/install.sh
+++ b/freeswitch/install.sh
@@ -76,9 +76,8 @@ esac
 
 # Install FreeSWITCH
 cd $FS_BASE_PATH
-git clone $FS_GIT_REPO --depth=1
+git clone $FS_GIT_REPO --depth=1 --branch=v.1.2.stable
 cd $FS_BASE_PATH/freeswitch
-git checkout -b v1.2.stable origin/v1.2.stable
 sh bootstrap.sh && ./configure --prefix=$FS_INSTALLED_PATH || exit 1
 [ -f modules.conf ] && cp modules.conf modules.conf.bak
 sed -i \


### PR DESCRIPTION
This automatically clones from the remote branch instead of
doing the branch switch locally.

The approach introduced in https://github.com/plivo/plivoframework/pull/125
does not work. It was working in the environment I was working on because
I automatically did some things to test the changes conveniently. I did _not_ test
for completely clean machines. The old way would fail, because it's a shallow
clone. It only kept one version of the repo's history and _ONLY_ for the master
branch. This is why it would fail when it switched to the stable branch.

I apologize for the trouble.
