### PR TITLE
Remove quotation marks around effective caller name

### DIFF
--- a/src/plivo/rest/freeswitch/elements.py
+++ b/src/plivo/rest/freeswitch/elements.py
@@ -808,7 +808,7 @@ class Dial(Element):
         if self.caller_name == 'none':
             outbound_socket.set("effective_caller_id_name=''")
         elif self.caller_name:
-            outbound_socket.set("effective_caller_id_name='%s'" % self.caller_name)
+            outbound_socket.set("effective_caller_id_name=%s" % self.caller_name)
         else:
             outbound_socket.unset("effective_caller_id_name")
         # Set continue on fail


### PR DESCRIPTION
Quotation marks around effective caller name don't work with phone number (double quoted in SIP header), so that this command:
`EXECUTE sofia/external/089123112312@sipconnect.sipgate.de set(effective_caller_id_name='498910002000')`
leads to this SIP header:
`From: "'498910002000'" <sip:`
which for obvious reasons is not accepted by the SIP trunk.
