### PR TITLE
Debian SysV init scripts

### DIFF
--- a/freeswitch/install.sh
+++ b/freeswitch/install.sh
@@ -76,7 +76,7 @@ esac
 
 # Install FreeSWITCH
 cd $FS_BASE_PATH
-git clone $FS_GIT_REPO --depth=1 --branch=v.1.2.stable
+git clone $FS_GIT_REPO --depth=1 --branch=v1.2.stable
 cd $FS_BASE_PATH/freeswitch
 sh bootstrap.sh && ./configure --prefix=$FS_INSTALLED_PATH || exit 1
 [ -f modules.conf ] && cp modules.conf modules.conf.bak

--- a/freeswitch/install.sh
+++ b/freeswitch/install.sh
@@ -40,7 +40,7 @@ echo "Setting up Prerequisites and Dependencies for FreeSWITCH"
 case $DIST in
     'DEBIAN')
         apt-get -y update
-        apt-get -y install autoconf automake autotools-dev binutils bison build-essential cpp curl flex g++ gcc git-core libaudiofile-dev libc6-dev libdb-dev libexpat1 libgdbm-dev libgnutls-dev libmcrypt-dev libncurses5-dev libnewt-dev libpcre3 libpopt-dev libsctp-dev libsqlite3-dev libtiff4 libtiff4-dev libtool libx11-dev libxml2 libxml2-dev lksctp-tools lynx m4 make mcrypt ncftp nmap openssl sox sqlite3 ssl-cert ssl-cert unixodbc-dev unzip zip zlib1g-dev zlib1g-dev libjpeg-dev libssl-dev sox
+        apt-get -y install autoconf automake autotools-dev binutils bison build-essential cpp curl flex g++ gcc git-core libaudiofile-dev libc6-dev libdb-dev libexpat1 libgdbm-dev libgnutls-dev libmcrypt-dev libncurses5-dev libnewt-dev libpcre3 libpopt-dev libsctp-dev libsqlite3-dev libtiff4-dev libtool libx11-dev libxml2 libxml2-dev lksctp-tools lynx m4 make mcrypt ncftp nmap openssl sox sqlite3 ssl-cert ssl-cert unixodbc-dev unzip wget zip zlib1g-dev zlib1g-dev libjpeg-dev libssl-dev sox
         ;;
     'CENTOS')
         yum -y update

--- a/freeswitch/install.sh
+++ b/freeswitch/install.sh
@@ -10,7 +10,7 @@ FS_GIT_REPO=https://stash.freeswitch.org/scm/fs/freeswitch.git
 FS_INSTALLED_PATH=/usr/local/freeswitch
 
 #####################################################
-FS_BASE_PATH=/usr/src/
+FS_BASE_PATH=/usr/src
 #####################################################
 
 CURRENT_PATH=$PWD
@@ -136,6 +136,28 @@ cd $FS_INSTALLED_PATH/conf/autoload_configs/
 wget --no-check-certificate $FS_CONF_PATH/conf/conference.conf.xml -O conference.conf.xml
 
 cd $CURRENT_PATH
+
+# Install init scripts
+case $DIST in
+    "DEBIAN")
+        echo "Adding freeswitch to /etc/init.d and /etc/default"
+        cp $FS_BASE_PATH/freeswitch/debian/freeswitch-sysvinit.freeswitch.init /etc/init.d/freeswitch
+        cp $FS_BASE_PATH/freeswitch/debian/freeswitch-sysvinit.freeswitch.default /etc/default/freeswitch
+        chmod +x /etc/init.d/freeswitch
+        chmod +x /etc/default/freeswitch
+        cd /etc/rc2.d
+        ln -s /etc/init.d/freeswitch S99freeswitch
+        sed -i -e "s|DAEMON=/usr/bin/freeswitch|DAEMON=$FS_INSTALLED_PATH/bin/freeswitch|" /etc/init.d/freeswitch
+        sed -i -e "s|CONFDIR=/etc/\$NAME|CONFDIR=$FS_INSTALLED_PATH/conf|" /etc/init.d/freeswitch
+        sed -i -e "s|WORKDIR=/var/lib/\$NAME|WORKDIR=$FS_INSTALLED_PATH|" /etc/init.d/freeswitch
+    ;;
+esac
+
+# Creating freeswitch user
+groupadd freeswitch
+adduser --disabled-password  --quiet --system --home /usr/local/freeswitch --gecos "FreeSWITCH Voice Platform" --ingroup daemon freeswitch
+chown -R freeswitch:daemon /usr/local/freeswitch/
+chmod -R o-rwx /usr/local/freeswitch/
 
 # Install Complete
 #clear


### PR DESCRIPTION
Copies the Debian SysV init scripts inside the Freeswitch repository. 

It then does string substitution for the paths since the one from
Freeswitch assumes it was installed where all of the installed
packages are, but the existing install script from Plivo assumes
it's in /usr/local/freeswitch
