### PR TITLE
Fix FS_GIT_REPO in freeswitch/install.sh

### DIFF
--- a/freeswitch/install.sh
+++ b/freeswitch/install.sh
@@ -6,7 +6,7 @@
 
 
 FS_CONF_PATH=https://github.com/plivo/plivoframework/raw/master/freeswitch
-FS_GIT_REPO=https://stash.freeswitch.org/scm/fs/freeswitch.git
+FS_GIT_REPO=https://freeswitch.org/stash/scm/fs/freeswitch.git
 FS_INSTALLED_PATH=/usr/local/freeswitch
 
 #####################################################


### PR DESCRIPTION
FS_GIT_REPO is changed from
https://stash.freeswitch.org/scm/fs/freeswitch.git
to
https://freeswitch.org/stash/scm/fs/freeswitch.git
.